### PR TITLE
Implement configuration and Canvas HTTP client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,190 @@
+use crate::config::CanvasConfig;
+use crate::error::{CanvasError, Result};
+use reqwest::{header, Client, Method, Response, StatusCode};
+use serde::de::DeserializeOwned;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Canvas API HTTP client
+#[derive(Clone)]
+pub struct CanvasClient {
+    client: Client,
+    config: Arc<CanvasConfig>,
+}
+
+impl CanvasClient {
+    /// Create a new Canvas client
+    pub fn new(config: Arc<CanvasConfig>) -> Result<Self> {
+        let mut headers = header::HeaderMap::new();
+
+        // Add authorization header
+        let auth_value = format!("Bearer {}", config.api_token);
+        headers.insert(
+            header::AUTHORIZATION,
+            header::HeaderValue::from_str(&auth_value)
+                .map_err(|e| CanvasError::config(format!("Invalid API token: {}", e)))?,
+        );
+
+        // Add user agent
+        headers.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_static("rust-canvas-mcp/0.1.0"),
+        );
+
+        // Build HTTP client with connection pooling and timeouts
+        let client = Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(10))
+            .pool_idle_timeout(Duration::from_secs(90))
+            .pool_max_idle_per_host(10)
+            .build()
+            .map_err(|e| CanvasError::config(format!("Failed to create HTTP client: {}", e)))?;
+
+        Ok(Self { client, config })
+    }
+
+    /// Get the base API URL
+    pub fn base_url(&self) -> &str {
+        &self.config.api_url
+    }
+
+    /// Build a URL for a Canvas API endpoint
+    pub fn build_url(&self, path: &str) -> String {
+        let base = self.config.api_url.trim_end_matches('/');
+        let path = path.trim_start_matches('/');
+        format!("{}/{}", base, path)
+    }
+
+    /// Execute a GET request and deserialize the response
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = self.build_url(path);
+        let response = self.client.get(&url).send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Execute a POST request with JSON body
+    pub async fn post<T: DeserializeOwned, B: serde::Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        let url = self.build_url(path);
+        let response = self.client.post(&url).json(body).send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Execute a PUT request with JSON body
+    pub async fn put<T: DeserializeOwned, B: serde::Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        let url = self.build_url(path);
+        let response = self.client.put(&url).json(body).send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Execute a DELETE request
+    pub async fn delete<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = self.build_url(path);
+        let response = self.client.delete(&url).send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Execute a request and return the raw response
+    pub async fn request(&self, method: Method, path: &str) -> Result<Response> {
+        let url = self.build_url(path);
+        let response = self.client.request(method, &url).send().await?;
+
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            Err(self.error_from_response(response).await)
+        }
+    }
+
+    /// Handle response and deserialize or return error
+    async fn handle_response<T: DeserializeOwned>(&self, response: Response) -> Result<T> {
+        let status = response.status();
+
+        if status.is_success() {
+            let text = response.text().await?;
+            serde_json::from_str(&text).map_err(|e| {
+                CanvasError::internal(format!(
+                    "Failed to parse Canvas API response: {}. Response: {}",
+                    e,
+                    text.chars().take(200).collect::<String>()
+                ))
+            })
+        } else {
+            Err(self.error_from_response(response).await)
+        }
+    }
+
+    /// Convert an error response into a CanvasError
+    async fn error_from_response(&self, response: Response) -> CanvasError {
+        let status = response.status();
+        let status_code = status.as_u16();
+
+        // Try to get error message from response body
+        let message = match response.text().await {
+            Ok(body) => {
+                // Try to parse JSON error
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+                    json.get("message")
+                        .or_else(|| json.get("error"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&body)
+                        .to_string()
+                } else {
+                    body
+                }
+            }
+            Err(_) => status
+                .canonical_reason()
+                .unwrap_or("Unknown error")
+                .to_string(),
+        };
+
+        match status {
+            StatusCode::UNAUTHORIZED => CanvasError::auth(message),
+            StatusCode::FORBIDDEN => CanvasError::auth(format!("Forbidden: {}", message)),
+            StatusCode::NOT_FOUND => CanvasError::not_found(message),
+            StatusCode::TOO_MANY_REQUESTS => {
+                CanvasError::RateLimit(format!("Rate limit exceeded: {}", message))
+            }
+            _ => CanvasError::api(status_code, message),
+        }
+    }
+
+    /// Get the current user (useful for testing connection)
+    pub async fn get_current_user(&self) -> Result<serde_json::Value> {
+        self.get("/users/self").await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_building() {
+        let config = Arc::new(CanvasConfig::new(
+            "token".to_string(),
+            "https://example.instructure.com/api/v1".to_string(),
+        ));
+
+        let client = CanvasClient::new(config).unwrap();
+
+        assert_eq!(
+            client.build_url("/courses"),
+            "https://example.instructure.com/api/v1/courses"
+        );
+
+        assert_eq!(
+            client.build_url("courses"),
+            "https://example.instructure.com/api/v1/courses"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,124 @@
+use crate::error::{CanvasError, Result};
+use std::env;
+
+/// Canvas MCP Server Configuration
+#[derive(Debug, Clone)]
+pub struct CanvasConfig {
+    /// Canvas API access token
+    pub api_token: String,
+
+    /// Canvas API base URL (e.g., https://institution.instructure.com/api/v1)
+    pub api_url: String,
+
+    /// Institution name (optional, for display purposes)
+    pub institution_name: Option<String>,
+
+    /// Timezone for date/time operations (optional)
+    pub timezone: Option<String>,
+
+    /// Enable data anonymization for student information
+    pub enable_anonymization: bool,
+
+    /// Debug mode
+    pub debug: bool,
+}
+
+impl CanvasConfig {
+    /// Load configuration from environment variables
+    pub fn from_env() -> Result<Self> {
+        // Load .env file if it exists
+        dotenvy::dotenv().ok();
+
+        let api_token = env::var("CANVAS_API_TOKEN").map_err(|_| {
+            CanvasError::config("CANVAS_API_TOKEN environment variable is required")
+        })?;
+
+        let api_url = env::var("CANVAS_API_URL")
+            .map_err(|_| CanvasError::config("CANVAS_API_URL environment variable is required"))?;
+
+        // Validate API URL
+        if !api_url.starts_with("http://") && !api_url.starts_with("https://") {
+            return Err(CanvasError::config(
+                "CANVAS_API_URL must start with http:// or https://",
+            ));
+        }
+
+        // Ensure API URL ends with /api/v1
+        let api_url = if api_url.ends_with("/api/v1") {
+            api_url
+        } else if api_url.ends_with('/') {
+            format!("{}api/v1", api_url)
+        } else {
+            format!("{}/api/v1", api_url)
+        };
+
+        let institution_name = env::var("INSTITUTION_NAME").ok();
+        let timezone = env::var("TIMEZONE").ok();
+
+        let enable_anonymization = env::var("ENABLE_DATA_ANONYMIZATION")
+            .unwrap_or_else(|_| "false".to_string())
+            .parse::<bool>()
+            .unwrap_or(false);
+
+        let debug = env::var("DEBUG")
+            .unwrap_or_else(|_| "false".to_string())
+            .parse::<bool>()
+            .unwrap_or(false);
+
+        Ok(Self {
+            api_token,
+            api_url,
+            institution_name,
+            timezone,
+            enable_anonymization,
+            debug,
+        })
+    }
+
+    /// Create a new configuration with the given values
+    pub fn new(api_token: String, api_url: String) -> Self {
+        // Normalize API URL to ensure it ends with /api/v1
+        let api_url = if api_url.ends_with("/api/v1") {
+            api_url
+        } else if api_url.ends_with('/') {
+            format!("{}api/v1", api_url)
+        } else {
+            format!("{}/api/v1", api_url)
+        };
+
+        Self {
+            api_token,
+            api_url,
+            institution_name: None,
+            timezone: None,
+            enable_anonymization: false,
+            debug: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_url_normalization() {
+        let config = CanvasConfig::new(
+            "token".to_string(),
+            "https://example.instructure.com".to_string(),
+        );
+        assert!(config.api_url.ends_with("/api/v1"));
+
+        let config2 = CanvasConfig::new(
+            "token".to_string(),
+            "https://example.instructure.com/".to_string(),
+        );
+        assert!(config2.api_url.ends_with("/api/v1"));
+
+        let config3 = CanvasConfig::new(
+            "token".to_string(),
+            "https://example.instructure.com/api/v1".to_string(),
+        );
+        assert!(config3.api_url.ends_with("/api/v1"));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,74 @@
+use thiserror::Error;
+
+/// Errors that can occur in the Canvas MCP server
+#[derive(Error, Debug)]
+pub enum CanvasError {
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// HTTP request error
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// JSON parsing error
+    #[error("JSON parsing error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Canvas API error
+    #[error("Canvas API error: {status} - {message}")]
+    Api { status: u16, message: String },
+
+    /// Resource not found
+    #[error("Resource not found: {0}")]
+    NotFound(String),
+
+    /// Authentication error
+    #[error("Authentication failed: {0}")]
+    Auth(String),
+
+    /// Rate limit exceeded
+    #[error("Rate limit exceeded: {0}")]
+    RateLimit(String),
+
+    /// Invalid parameter
+    #[error("Invalid parameter: {0}")]
+    InvalidParameter(String),
+
+    /// Internal error
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+/// Result type for Canvas operations
+pub type Result<T> = std::result::Result<T, CanvasError>;
+
+impl CanvasError {
+    /// Create a configuration error
+    pub fn config(msg: impl Into<String>) -> Self {
+        Self::Config(msg.into())
+    }
+
+    /// Create an API error from status and message
+    pub fn api(status: u16, message: impl Into<String>) -> Self {
+        Self::Api {
+            status,
+            message: message.into(),
+        }
+    }
+
+    /// Create a not found error
+    pub fn not_found(msg: impl Into<String>) -> Self {
+        Self::NotFound(msg.into())
+    }
+
+    /// Create an authentication error
+    pub fn auth(msg: impl Into<String>) -> Self {
+        Self::Auth(msg.into())
+    }
+
+    /// Create an internal error
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self::Internal(msg.into())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,12 @@
+/// Canvas MCP Server Library
+///
+/// This library provides the core functionality for the Canvas MCP server,
+/// including configuration, HTTP client, and Canvas API integrations.
+pub mod client;
+pub mod config;
+pub mod error;
+
+// Re-export commonly used types
+pub use client::CanvasClient;
+pub use config::CanvasConfig;
+pub use error::{CanvasError, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,93 @@
-fn main() {
+use rust_canvas_mcp::{CanvasClient, CanvasConfig};
+use std::env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Check for --test flag
+    let args: Vec<String> = env::args().collect();
+    if args.len() > 1 && args[1] == "--test" {
+        return run_connection_test().await;
+    }
+
     println!("Rust Canvas MCP Server");
     println!("Version: {}", env!("CARGO_PKG_VERSION"));
-    println!("This is a placeholder. Full implementation coming in Phase 2.");
+    println!();
+    println!("This is a Phase 2 implementation demonstrating:");
+    println!("- Configuration loading from environment");
+    println!("- Canvas API HTTP client");
+    println!("- Connection testing");
+    println!();
+    println!("Usage:");
+    println!("  cargo run -- --test    Test Canvas API connection");
+    println!();
+    println!("Full MCP server implementation coming in Phase 2 (Issue #4)");
+
+    Ok(())
+}
+
+/// Run connection test
+async fn run_connection_test() -> anyhow::Result<()> {
+    println!("Testing Canvas API connection...");
+    println!();
+
+    // Load configuration
+    let config = match CanvasConfig::from_env() {
+        Ok(cfg) => {
+            println!("✓ Configuration loaded");
+            if let Some(ref inst) = cfg.institution_name {
+                println!("  Institution: {}", inst);
+            }
+            println!("  API URL: {}", cfg.api_url);
+            cfg
+        }
+        Err(e) => {
+            eprintln!("✗ Configuration error: {}", e);
+            eprintln!();
+            eprintln!("Please ensure the following environment variables are set:");
+            eprintln!("  CANVAS_API_TOKEN - Your Canvas API access token");
+            eprintln!("  CANVAS_API_URL - Your Canvas API URL (e.g., https://institution.instructure.com/api/v1)");
+            std::process::exit(1);
+        }
+    };
+
+    // Create HTTP client
+    let client = match CanvasClient::new(Arc::new(config)) {
+        Ok(c) => {
+            println!("✓ HTTP client created");
+            c
+        }
+        Err(e) => {
+            eprintln!("✗ Failed to create HTTP client: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Test connection by fetching current user
+    print!("Testing API connection... ");
+    match client.get_current_user().await {
+        Ok(user) => {
+            println!("✓");
+            if let Some(name) = user.get("name").and_then(|v| v.as_str()) {
+                println!("✓ Connected as: {}", name);
+            }
+            if let Some(id) = user.get("id").and_then(|v| v.as_u64()) {
+                println!("  User ID: {}", id);
+            }
+            println!();
+            println!("✓ All tests passed!");
+        }
+        Err(e) => {
+            println!("✗");
+            eprintln!("✗ API connection failed: {}", e);
+            eprintln!();
+            eprintln!("Please check:");
+            eprintln!("  - Your API token is valid");
+            eprintln!("  - Your API URL is correct");
+            eprintln!("  - You have network access to Canvas");
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Changes
- Add comprehensive error types with CanvasError enum
- Implement CanvasConfig with environment variable loading  
- Create CanvasClient with async HTTP operations and connection pooling
- Add URL normalization to ensure /api/v1 suffix
- Implement request methods (GET, POST, PUT, DELETE)
- Add proper error handling for Canvas API responses
- Include connection test via `--test` flag
- Add unit tests for config and client modules

## Testing
- ✅ All unit tests pass
- ✅ Clippy and fmt checks pass
- ✅ Connection test demonstrates functionality

## Usage
```bash
# Test Canvas API connection
CANVAS_API_TOKEN=your_token CANVAS_API_URL=https://your-institution.instructure.com cargo run -- --test
```

Resolves #3